### PR TITLE
Update README Example to Point To Correct Location

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ More Useage see:
 
 ```ts
 import { assertEquals, runTests, test } from "./deps.ts";
-import { Query } from "https://deno.land/x/sql-builder@1.3.5/mod.ts";
+import { Query } from "https://deno.land/x/sql_builder/mod.ts";
 
 test(function testQueryInsert() {
   const builder = new Query();


### PR DESCRIPTION
The module path described in `import` was pointing to an incorrect location. Changed the `-` to a `_`.