### PR TITLE
Fix import warning

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,5 @@
 export {
   assert,
   assertEquals,
-} from "https://deno.land/std@v0.51.0/testing/asserts.ts";
+} from "https://deno.land/std@0.51.0/testing/asserts.ts";
 export { replaceParams } from "./util.ts";


### PR DESCRIPTION
When running `deno test` I got the following warning:

> Warning std versions prefixed with 'v' will be deprecated on October 1st 2020. Please change your import to https://deno.land/std@0.51.0/testing/asserts.ts (at https://deno.land/std@v0.51.0/testing/asserts.ts)