### PR TITLE
replaceParams should escape \ characters

### DIFF
--- a/test/util.ts
+++ b/test/util.ts
@@ -32,8 +32,10 @@ test("testIdReplace", function () {
   assertEquals(replaceParams("??", [1]), "`1`");
   assertEquals(replaceParams("??", [true]), "`true`");
   assertEquals(replaceParams("?", ["string"]), `"string"`);
+  assertEquals(replaceParams("?", ["str\\ing"]), `"str\\\\ing"`);
   assertEquals(replaceParams("?", [123]), `123`);
   assertEquals(replaceParams("?", [`"test"`]), '"\\"test\\""');
+  assertEquals(replaceParams("?", [`\\"test"`]), '"\\\\\\"test\\""');
   assertEquals(replaceParams("?", [["a", "b", "c", "d"]]), '("a","b","c","d")');
   assertEquals(replaceParams("?", [[1, 2, 3, 4]]), "(1,2,3,4)");
   assertEquals(replaceParams("??", [["a", "b", "c"]]), "(`a`,`b`,`c`)");

--- a/util.ts
+++ b/util.ts
@@ -14,14 +14,13 @@ export function replaceParams(sql: string, params: any | any[]): string {
         return `(${val.map((item) => replaceParams("??", [item])).join(",")})`;
       } else if (val === "*") {
         return val;
-      } else if (typeof val === "string" && val.indexOf(".") > -1) {
+      } else if (typeof val === "string" && val.includes(".")) {
         // a.b => `a`.`b`
         const _arr = val.split(".");
         return replaceParams(_arr.map(() => "??").join("."), _arr);
       } else if (
         typeof val === "string" &&
-        (val.toLowerCase().indexOf(" as ") > -1 ||
-          val.toLowerCase().indexOf(" AS ") > -1)
+        (val.includes(" as ") || val.includes(" AS "))
       ) {
         // a as b => `a` AS `b`
         const newVal = val.replace(" as ", " AS ");
@@ -81,5 +80,5 @@ function formatDate(date: Date) {
 }
 
 function escapeString(str: string) {
-  return str.replace(/"/g, '\\"');
+  return str.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 }


### PR DESCRIPTION
When using replaceParams to insert a string into a SQL string, it should
escape backslashes as a pair of backslashes.

replaceParams escapes " characters as \".

Before this change, if the input string was
\"
then the output string would be
\\"
which would mean the " character was no longer escaped.

https://dev.mysql.com/doc/refman/8.0/en/string-literals.html#character-escape-sequences

This commit includes a few small other changes to replaceParams.
Where `indexOf` was used to determine if a string contained a pattern
I've replaced it with `includes`. This is better for people like me who
aren't primarily Javascript/Typescript programmers.

```
-        (val.toLowerCase().indexOf(" as ") > -1 ||
-          val.toLowerCase().indexOf(" AS ") > -1)
```

The 2nd condition was never true because if the string is forced lower
case it will never contain some uppper case characters.

manyuanrong/deno_mysql#57