### PR TITLE
feat: add clone method to Query.

### DIFF
--- a/query.ts
+++ b/query.ts
@@ -189,19 +189,19 @@ export class Query {
   }
 
   clone() {
-    const c = new Query();
-    c._type = this._type;
-    c._table = this._table;
-    c._where = this._where;
-    c._joins = this._joins;
-    c._orders = this._orders;
-    c._fields = this._fields;
-    c._groupBy = this._groupBy;
-    c._having = this._having;
-    c._insertValues = this._insertValues;
-    c._updateValue = this._updateValue;
-    c._limit = this._limit;
-    return c;
+    const newQuery = new Query();
+    newQuery._type = this._type;
+    newQuery._table = this._table;
+    newQuery._where = this._where;
+    newQuery._joins = this._joins;
+    newQuery._orders = this._orders;
+    newQuery._fields = this._fields;
+    newQuery._groupBy = this._groupBy;
+    newQuery._having = this._having;
+    newQuery._insertValues = this._insertValues;
+    newQuery._updateValue = this._updateValue;
+    newQuery._limit = this._limit;
+    return newQuery;
   }
 
   build(): string {

--- a/query.ts
+++ b/query.ts
@@ -188,6 +188,22 @@ export class Query {
     return this;
   }
 
+  clone() {
+    const c = new Query();
+    c._type = this._type;
+    c._table = this._table;
+    c._where = this._where;
+    c._joins = this._joins;
+    c._orders = this._orders;
+    c._fields = this._fields;
+    c._groupBy = this._groupBy;
+    c._having = this._having;
+    c._insertValues = this._insertValues;
+    c._updateValue = this._updateValue;
+    c._limit = this._limit;
+    return c;
+  }
+
   build(): string {
     assert(!!this._table);
     switch (this._type) {

--- a/test/query.ts
+++ b/test/query.ts
@@ -177,3 +177,14 @@ test("testQuerySelectLimit", function () {
     'SELECT * FROM `users` WHERE `id` > 1 AND `name` LIKE "%n%" LIMIT 0, 10',
   );
 });
+
+test("testQueryClone", function () {
+  const builder = new Query();
+  builder.table("users");
+  const clonedBuilder = builder.clone();
+  const clonedSql = clonedBuilder.select("gender", "avatar").build();
+  const sql = builder.select("name", "id").build();
+
+  assertEquals(sql.trim(), "SELECT `name`, `id` FROM `users`");
+  assertEquals(clonedSql.trim(), "SELECT `gender`, `avatar` FROM `users`");
+});


### PR DESCRIPTION
support use cases in which we need to create similar sql.
eg: get data list and record count in same (where) condition.  
```ts
const builder = new Query();
builder.table("goods");
if (texture) {
  builder.where(Where.like("texture", `%${texture}%`));
}
const countBuilder = builder.clone().select("count(*) as c");
builder.select("*").limit((page - 1) * pagesize, pagesize);
const sql = builder.build();
const countSql = countBuilder.build();
logger.info(sql); // SELECT * FROM `goods` WHERE `texture` LIKE "%silk%" LIMIT 0, 10
logger.info(countSql); // SELECT count(*) as c FROM `goods` WHERE `texture` LIKE "%silk%"
```