### PR TITLE
fix notNull(?? NOT NULL) -> isNotNull(?? IS NOT NULL) (#25)

### DIFF
--- a/test/where.ts
+++ b/test/where.ts
@@ -45,11 +45,11 @@ test("testWhereLte", function () {
   assertEquals(Where.field("age").lte(10).value, sql);
 });
 
-test("testWhereNotNull", function () {
-  const sql = "`age` NOT NULL";
-  assertEquals(Where.expr("?? NOT NULL", "age").value, sql);
-  assertEquals(Where.notNull("age").value, sql);
-  assertEquals(Where.field("age").notNull().value, sql);
+test("testWhereIsNotNull", function () {
+  const sql = "`age` IS NOT NULL";
+  assertEquals(Where.expr("?? IS NOT NULL", "age").value, sql);
+  assertEquals(Where.isNotNull("age").value, sql);
+  assertEquals(Where.field("age").isNotNull().value, sql);
 });
 
 test("testWhereIsNull", function () {

--- a/where.ts
+++ b/where.ts
@@ -64,6 +64,10 @@ export class Where {
     return this.expr("?? NOT NULL", field);
   }
 
+  static isNotNull(field: string) {
+    return this.expr("?? IS NOT NULL", field);
+  }
+
   static in(field: string, ...values: any[]) {
     const params: any[] = values.length > 1 ? values : values[0];
     return this.expr("?? IN ?", field, params);
@@ -91,7 +95,7 @@ export class Where {
       ne: (value: any) => this.ne(name, value),
       eq: (value: any) => this.eq(name, value),
       isNull: () => this.isNull(name),
-      notNull: () => this.notNull(name),
+      isNotNull: () => this.isNotNull(name),
       in: (...values: any[]) => this.in(name, ...values),
       notIn: (...values: any[]) => this.notIn(name, ...values),
       like: (value: any) => this.like(name, value),

--- a/where.ts
+++ b/where.ts
@@ -60,10 +60,6 @@ export class Where {
     return this.expr("?? IS NULL", field);
   }
 
-  static notNull(field: string) {
-    return this.expr("?? NOT NULL", field);
-  }
-
   static isNotNull(field: string) {
     return this.expr("?? IS NOT NULL", field);
   }


### PR DESCRIPTION
`X NOT NULL` is used for `create table`, etc.
As an `SELECT` clause, `X IS NOT NULL` is more correct.